### PR TITLE
fixed install and run commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,11 +85,11 @@ to deal with the legal aspects, let me know.
 
 ## Installing
 
-The game uses node.js as server and depends on some npm packages.  It can
-itself be installed using npm:
+The game uses node.js as server and depends on some npm packages.  To install
+dependencies:
 
 ```
-$ npm install html-scrabble
+$ npm install
 ```
 
 ## Configuration
@@ -136,7 +136,7 @@ Once you're satisfied with the configuration, you can start the game
 server using
 
 ```
-$ npm start html-scrabble
+$ node server.js
 ```
 
 Open your web browser on the configured game URL to create a new game.


### PR DESCRIPTION
npm doesn't like installing itself.
$ npm install html-scrabble
Refusing to install html-scrabble as a dependency of itself
