### PR TITLE
remove warning message 'Option log level is not valid'

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
         "nodemailer": ">=0.3.22",
         "nodeunit": ">=0.7.4",
         "optimist": ">=0.3.4",
-        "socket.io": ">=0.9.9",
+        "socket.io": ">=1.0.5",
         "underscore": ">=1.3.3",
         "icebox": "=0.1.1"
     },

--- a/server.js
+++ b/server.js
@@ -74,8 +74,6 @@ var server = app.listen(config.port)
 var io = io.listen(server);
 var db = new DB.DB(argv.database);
 
-io.set('log level', 1);
-
 app.configure(function() {
     app.use(express.methodOverride());
     app.use(express.bodyParser());


### PR DESCRIPTION
Debugging in socket.io has changed. See https://github.com/Automattic/socket.io#debug--logging
