### PR TITLE
Do not use Nodemailer >= 1.0.

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
         "body-parser": ">=1.3.1",
         "errorhandler": ">=1.1.0",
 	"basic-auth-connect" : ">=1.0.0",
-        "nodemailer": ">=0.3.22",
+        "nodemailer": "0.3.22 - 0.7",
         "nodeunit": ">=0.7.4",
         "optimist": ">=0.3.4",
         "socket.io": ">=1.0.5",


### PR DESCRIPTION
Nodemailer as of 1.0 is incompatible with older code. http://documentup.com/andris9/nodemailer/ advises to use the 0.7 branch.
This fix limits the allowed versions of nodemailer to 0.3.22 - 0.7.