### PR TITLE
Prevent errors when mail transport is not defined

### DIFF
--- a/server.js
+++ b/server.js
@@ -205,16 +205,21 @@ Game.prototype.sendInvitation = function(player, subject)
         const gameLink = this.makeLink(player)
         console.log('sendInvitation to', player.name, 'subject', subject);
         console.log('link: ', gameLink);
-        smtp.sendMail({ from: config.mailSender,
-                        to:  player.email,
-                        subject: subject,
-                        text: 'Make your move:\n\n' + gameLink,
-                        html: 'Click <a href="' + gameLink + '">here</a> to make your move.' },
-                      function (err) {
-                          if (err) {
-                              console.log('sending mail failed', err);
-                          }
-                      });
+
+        if (smtp === undefined) {
+          console.log("No email transport defined. Email will not be sent.");
+        } else {
+          smtp.sendMail({ from: config.mailSender,
+            to:  player.email,
+            subject: subject,
+            text: 'Make your move:\n\n' + gameLink,
+            html: 'Click <a href="' + gameLink + '">here</a> to make your move.' },
+            function (err) {
+              if (err) {
+                console.log('sending mail failed', err);
+              }
+            });
+        }
     }
     catch (e) {
         console.log('cannot send mail:', e);


### PR DESCRIPTION
This change prevents errors appearing in the log if a
mailTransportConfig is not defined in the config file (i.e. if you don't
want the application to try and send email invitations).