### PR TITLE
Fix arguments of `createTransport`

### DIFF
--- a/server.js
+++ b/server.js
@@ -51,7 +51,7 @@ function maybeLoadConfig() {
             config.baseUrl = process.env.BASE_URL ? process.env.BASE_URL : config.baseUrl;
 
             if (config.mailTransportConfig) {
-              smtp = nodemailer.createTransport('SMTP', config.mailTransportConfig);
+              smtp = nodemailer.createTransport(config.mailTransportConfig);
             } else if (process.env.MAILGUN_SMTP_SERVER) {
               config.mailSender = `scrabble@${process.env.MAILGUN_DOMAIN}`;
               smtp = nodemailer.createTransport({


### PR DESCRIPTION
This PR fixes a bug occuring when using a non-local SMTP server.

Nodemailer's `createTransport` either takes an an options object or a URL as an argument (Version 6.4.6, https://nodemailer.com/smtp/).

Current call results in an error:

```
error reading configuration:
TypeError: Cannot create property 'mailer' on string 'SMTP'
```