### PR TITLE
Fix smtp transport from config isn't working

### DIFF
--- a/server.js
+++ b/server.js
@@ -218,7 +218,7 @@ Game.prototype.sendInvitation = async function(player, subject)
         console.log('sendInvitation to', player.name, 'subject', subject);
         console.log('link: ', gameLink);
 
-        if (smtp === undefined) {
+        if (smtp !== undefined) {
           const mailResult = await smtp.sendMail({ from: config.mailSender,
             to:  player.email,
             subject: subject,


### PR DESCRIPTION
The clause is the inverse of that required. When nodemailer is assigned to smtp, it won't send the mail! 

