### PR TITLE
bug in moving tile from SwapRack to Rack

### DIFF
--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -530,13 +530,18 @@ UI.prototype.eventCallback = function(f) {
 };
 
 UI.prototype.idToSquare = function(id) {
-    var match = id.match(/(Board|Rack)_(\d+)x?(\d*)/);
+    var match = id.match(/^(SwapRack|Board|Rack)_(\d+)x?(\d*)/);
     if (match) {
         if (match[1] == 'Board') {
             return this.board.squares[match[2]][match[3]];
-        } else {
+        } else if (match[1] == 'Rack') {
             return this.rack.squares[match[2]];
+        } else if (match[1] == 'SwapRack') {
+            return this.swapRack.squares[match[2]];
+        } else {
+            throw "cannot find tile " + id;
         }
+
     } else {
         throw "cannot parse id " + id;
     }


### PR DESCRIPTION
Drag-and-drop a tile  from the Swap Rack to the Rack:

*  If the Rack happens to already have a tile in the index which is the old index in the SwapRack., then the tile from the Rack is cloned!
* Otherwise,  the "drop"  crashes on an undefined object. Console says: ` “Uncaught TypeError: tile is undefined    moveTile http://localhost:9093/javascript/ui.js:897”`
* Visually, that appears as the tile getting stuck.

![image](https://user-images.githubusercontent.com/4542591/131397106-9b2fb173-c09e-41fb-a956-e9769a147ebe.png)

* The issue is just that the regex never captures "SwapRack" as compared to "Rack". See commit.
