### PR TITLE
Blanking blanks on return to rack

### DIFF
--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -894,33 +894,36 @@ UI.prototype.moveTile = function(fromSquare, toSquare) {
     var ui = this;
     fromSquare.placeTile(null);
     fromSquare.owner.tileCount--;
-    if (tile.isBlank() && !tile.letter || (tile.letter == ' ')) {
-        if (fromSquare.owner != this.board && toSquare.owner == this.board) {
-            var blankLetterRequesterButton = $("#blankLetterRequester button");
-            var blankLetterRequesterSkip = $("#blankLetterRequesterSkip button");
-            function setLetter(letter) {
-                tile.letter = letter;
-                $.unblockUI();
-                ui.updateSquare(toSquare);
-                $('#dummyInput').focus();
-                blankLetterRequesterSkip.off('click');
-                blankLetterRequesterButton.off('keypress');
-            }
-            blankLetterRequesterButton.on('keypress', function (event) {
-                var letter = String.fromCharCode(event.charCode);
-                if (letter != '') {
-                    letter = letter.toUpperCase();
-                    if (ui.legalLetters.indexOf(letter) != -1) {
-                        setLetter(letter);
-                    }
-                }
-            });
-            blankLetterRequesterSkip.on('click', function (){
-                setLetter("_")
-            });
-            $.blockUI({ message: $('#blankLetterRequester') });
-        } else if (toSquare.owner == ui.rack || toSquare.owner == ui.swapRack) {
+
+    if (tile.isBlank()) {
+        if (toSquare.owner == ui.rack || toSquare.owner == ui.swapRack) {
             tile.letter = ' ';
+        } else  if ( !tile.letter || (tile.letter == ' ')) {
+            if (fromSquare.owner != this.board && toSquare.owner == this.board) {
+                var blankLetterRequesterButton = $("#blankLetterRequester button");
+                var blankLetterRequesterSkip = $("#blankLetterRequesterSkip button");
+                function setLetter(letter) {
+                    tile.letter = letter;
+                    $.unblockUI();
+                    ui.updateSquare(toSquare);
+                    $('#dummyInput').focus();
+                    blankLetterRequesterSkip.off('click');
+                    blankLetterRequesterButton.off('keypress');
+                }
+                blankLetterRequesterButton.on('keypress', function (event) {
+                    var letter = String.fromCharCode(event.charCode);
+                    if (letter != '') {
+                        letter = letter.toUpperCase();
+                        if (ui.legalLetters.indexOf(letter) != -1) {
+                            setLetter(letter);
+                        }
+                    }
+                });
+                blankLetterRequesterSkip.on('click', function (){
+                    setLetter("_")
+                });
+                $.blockUI({ message: $('#blankLetterRequester') });
+            }
         }
     }
     toSquare.placeTile(tile);


### PR DESCRIPTION
To reproduce: Midturn, take a blank tile (which has been assigned a letter) from the board to the rack.

Bug: That chosen letter stays chosen. 

Fix: Instead, blank out that tile, so that the player can then replay the tile and choose a different letter.

Code: The `if` statements are wrongly nested. We simply move an `if` to one nesting-level higher.