### PR TITLE
Use standard shuffle

### DIFF
--- a/client/javascript/scrabble.js
+++ b/client/javascript/scrabble.js
@@ -586,14 +586,7 @@ LetterBag.create = function(language) {
 
 LetterBag.prototype.shake = function()
 {
-    var count = this.tiles.length;
-    for (i = 0; i < count * 3; i++) {
-        var a = Math.floor(Math.random() * count);
-        var b = Math.floor(Math.random() * count);
-        var tmp = this.tiles[b];
-        this.tiles[b] = this.tiles[a];
-        this.tiles[a] = tmp;
-    }
+   this.tiles  = _.shuffle(this.tiles);
 };
 
 LetterBag.prototype.getRandomTile = function()


### PR DESCRIPTION
As-is:

 Other testers and I have seen that letters, as they  automatically pulled from the bag, tend strongly to bunch together, particularly at the end of the game The shuffling is non-random.

Why to fix:

-  It's usually best to use packaged, tested algo implementations.
- The current[ algo is said to be imperfect](https://stats.stackexchange.com/questions/3082). Logically it seems that the imperfection is small, but the bug we see is clear.
 

Fix: 

Underscore's `_.shuffle()`  which uses the standard Fisher-Yates  algo.