### PR TITLE
Enforce filled blank

### DIFF
--- a/client/game.html
+++ b/client/game.html
@@ -89,9 +89,7 @@
         <div id="letters" class="tableDivWrap" style="display:none;"></div>
       </div>
       <div id="blankLetterRequester">
-          <button>Type blank's letter</button>
-          or
-          <div id="blankLetterRequesterSkip"><button>leave empty</button>
+          <button>Type letter for blank</button>
       </div>
     </div>
   </body>

--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -902,13 +902,13 @@ UI.prototype.moveTile = function(fromSquare, toSquare) {
     if (tile.isBlank() && !tile.letter || (tile.letter == ' ')) {
         if (fromSquare.owner != this.board && toSquare.owner == this.board) {
             var blankLetterRequesterButton = $("#blankLetterRequester button");
-            var blankLetterRequesterSkip = $("#blankLetterRequesterSkip button");
+
             function setLetter(letter) {
                 tile.letter = letter;
                 $.unblockUI();
                 ui.updateSquare(toSquare);
                 $('#dummyInput').focus();
-                blankLetterRequesterSkip.off('click');
+
                 blankLetterRequesterButton.off('keypress');
             }
             blankLetterRequesterButton.on('keypress', function (event) {
@@ -920,9 +920,7 @@ UI.prototype.moveTile = function(fromSquare, toSquare) {
                     }
                 }
             });
-            blankLetterRequesterSkip.on('click', function (){
-                setLetter("_")
-            });
+
             $.blockUI({ message: $('#blankLetterRequester') });
         } else if (toSquare.owner == ui.rack || toSquare.owner == ui.swapRack) {
             tile.letter = ' ';

--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -906,13 +906,11 @@ UI.prototype.moveTile = function(fromSquare, toSquare) {
         } else  if ( !tile.letter || (tile.letter == ' ')) {
             if (fromSquare.owner != this.board && toSquare.owner == this.board) {
                 var blankLetterRequesterButton = $("#blankLetterRequester button");
-                var blankLetterRequesterSkip = $("#blankLetterRequesterSkip button");
                 function setLetter(letter) {
                     tile.letter = letter;
                     $.unblockUI();
                     ui.updateSquare(toSquare);
                     $('#dummyInput').focus();
-                    blankLetterRequesterSkip.off('click');
                     blankLetterRequesterButton.off('keypress');
                 }
                 blankLetterRequesterButton.on('keypress', function (event) {
@@ -924,9 +922,7 @@ UI.prototype.moveTile = function(fromSquare, toSquare) {
                         }
                     }
                 });
-                blankLetterRequesterSkip.on('click', function (){
-                    setLetter("_")
-                });
+
                 $.blockUI({ message: $('#blankLetterRequester') });
             }
         }


### PR DESCRIPTION
As-is: You have the option of leaving a blank tile blank

Why that is a problem
1. The log pane simply omits these letters. Instead of CHEESE or CHE_SE, you see CHESE.
E.g., gere you see words "S" and "EIDUA" even though there is another letter in each. 

<img width="261" alt="image" src="https://user-images.githubusercontent.com/4542591/131641136-68e9efef-284b-44f0-a855-29576c5e3e62.png">
<img width="273" alt="image" src="https://user-images.githubusercontent.com/4542591/131641222-5ad65f3e-ed6a-463b-b66f-4a6b1cbeccf9.png">

Seeing "_S" and "EIDUA_" would be nice, but:

3. The rules of Scrabble state that a blank must serve with the same letter even in multiple crossing words.

Solution:
Enforce the choice of a letter. Remove option of leaving it blank.