### PR TITLE
Chat on explicit keypress

### DIFF
--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -350,10 +350,14 @@ function UI(game) {
             .bind('focus', function() {
                 ui.clearCursor();
             })
-            .bind('change', function() {
-                ui.socket.emit('message', { name: ui.thisPlayer.name,
-                                            text: $(this).val() });
-                $(this).val('');
+            .bind('keypress', function(evt) {
+                if (evt.charCode===13) {
+                    ui.socket.emit('message', {
+                        name: ui.thisPlayer.name,
+                        text: $(this).val()
+                    });
+                    $(this).val('');
+                }
             });
         $(document)
             .bind('SquareChanged', ui.eventCallback(ui.updateSquare))

--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -351,7 +351,7 @@ function UI(game) {
                 ui.clearCursor();
             })
             .bind('keypress', function(evt) {
-                if (evt.charCode===13) {
+                if (evt.charCode==13) {
                     ui.socket.emit('message', {
                         name: ui.thisPlayer.name,
                         text: $(this).val()


### PR DESCRIPTION
* As-is: Send chat  message on lose-focus.  This can come as a surprise to the users. It  can be embarrassing for a message to go out before you expect it.
* Fix: Send message only on explicitly submitting the chat-field.