### PR TITLE
swap tiles

### DIFF
--- a/client/javascript/ui.js
+++ b/client/javascript/ui.js
@@ -1127,8 +1127,10 @@ UI.prototype.swapTiles = function() {
     ui.endMove();
     var letters = ui.swapRack.letters();
     ui.swapRack.squares.forEach(function(square) {
+        if (square.tile){
+            ui.swapRack.tileCount--;
+        }
         square.placeTile(null);
-        ui.swapRack.tileCount--;
     });
     ui.sendMoveToServer('swap',
                         letters,


### PR DESCRIPTION

Behavior of app: After you swap tiles, on the next turn when you put tiles in the Swap Rack, you do not see the "Swap" button.  Refreshing the browser fixes this.

Cause in code: In `swapTiles`, we decrement the `swapRack.tileCount` for *all seven* squares in the Swap Rack, even if only a few of these actually have a tile. This results in a *negative* count.

Fix: Decrement only for the actual tiles that are being swapped out.

Design comment: To avoid duplicate state, it would be better not to have `swapRack.tileCount` but rather count the tiles in the SwapRack on-demand. I did not fix that.